### PR TITLE
Update Go versions in CI and go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                go: ['1.20', '1.21', '1.22', '1.23', '1.24']
+                go: ['1.21', '1.22', '1.23', '1.24']
         steps:
             - name: Harden Runner
               uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@
 
 module github.com/wneessen/iocrypter
 
-go 1.20
+go 1.23.0
+
+toolchain go1.24.0
 
 require golang.org/x/crypto v0.34.0
 


### PR DESCRIPTION
Removed Go 1.20 from the CI matrix and updated the minimum required Go version in go.mod to 1.23.0. Specified toolchain directive for Go 1.24.0 to ensure compatibility and future-proofing.