### PR TITLE
Codec Interface support for Alex Edwards' SCS: HTTP Session Management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                go: ['1.21', '1.22', '1.23', '1.24']
+                go: ['1.24']
         steps:
             - name: Harden Runner
               uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,7 @@
 
 module github.com/wneessen/iocrypter
 
-go 1.23.0
-
-toolchain go1.24.0
+go 1.24
 
 require golang.org/x/crypto v0.35.0
 

--- a/scs/README.md
+++ b/scs/README.md
@@ -1,4 +1,5 @@
-# dbenc - SCS Codec Interface
+# scs_codec
+## SCS Codec Interface for session encryption and authentication using iocrypter
 
 ## Overview
 

--- a/scs/README.md
+++ b/scs/README.md
@@ -1,0 +1,38 @@
+# dbenc - SCS Codec Interface
+
+## Overview
+
+The `scs_codec` package provides an implementation of the Codec interface
+for [Alex Edwards' SCS: HTTP Session Management](https://github.com/alexedwards/scs). It enables the use
+of [iocrypter](https://github.com/wneessen/iocrypter) to encrypt and authenticate session data before storing 
+them in any supported SCS session storage.
+
+## Usage
+
+### Importing
+
+```go
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/alexedwards/scs/v2"
+	scscrypter "github.com/wneessen/iocrypter/scs_codec/scs"
+)
+
+func main() {
+	// Initialize a new session manager and set dbenc as Codec
+	sessionManager = scs.New()
+	sessionManager.Codec = scscrypter.New("VeryS3curE.P4ssPh4$3!")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/session", yourSessionHandler)
+	http.ListenAndServe(":4000", sessionManager.LoadAndSave(mux))
+}
+```
+
+## License
+
+This package is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/scs/README.md
+++ b/scs/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: Winni Neessen <wn@neessen.dev>
+
+SPDX-License-Identifier: MIT
+-->
+
 # scs_codec
 ## SCS Codec Interface for session encryption and authentication using iocrypter
 

--- a/scs/README.md
+++ b/scs/README.md
@@ -4,12 +4,12 @@ SPDX-FileCopyrightText: Winni Neessen <wn@neessen.dev>
 SPDX-License-Identifier: MIT
 -->
 
-# scs_codec
+# scs
 ## SCS Codec Interface for session encryption and authentication using iocrypter
 
 ## Overview
 
-The `scs_codec` package provides an implementation of the Codec interface
+The `scs` package provides an implementation of the Codec interface
 for [Alex Edwards' SCS: HTTP Session Management](https://github.com/alexedwards/scs). It enables the use
 of [iocrypter](https://github.com/wneessen/iocrypter) to encrypt and authenticate session data before storing 
 them in any supported SCS session storage.
@@ -26,7 +26,7 @@ import (
 	"net/http"
 
 	"github.com/alexedwards/scs/v2"
-	scscrypter "github.com/wneessen/iocrypter/scs_codec/scs"
+	scscrypter "github.com/wneessen/iocrypter/scs"
 )
 
 func main() {

--- a/scs/scs_codec.go
+++ b/scs/scs_codec.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Winni Neessen <wn@neessen.dev>
+//
+// SPDX-License-Identifier: MIT
+
+// Package scs_codec implements the Codec interface of Alex Edward's SCS Session Management
+// package so that iocrypter can be used for encrypting/authenticating session data before
+// storing them in memory or in any other corrsponding session storage that is supported by
+// SCS.
+package scs_codec
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/wneessen/iocrypter"
+)
+
+// Codec provides encoding and decoding functionality for securely storing
+// session data. It satisfies the scs.Codec interface and uses iocrypter as base
+// for the encryption and decryption process.
+type Codec struct {
+	pass []byte
+}
+
+// New initializes and returns a new Codec instance using the provided AEAD
+// cipher for encryption.
+//
+// Parameters:
+//   - aead (cipher.AEAD): An AEAD cipher used to initialize the encryption
+//     mechanism.
+//
+// Returns:
+//   - Codec: A new pointer to an instance of Codec configured with the provided
+//     AEAD cipher.
+func New(pass string) *Codec {
+	return &Codec{
+		pass: []byte(pass),
+	}
+}
+
+// Encode serializes and encrypts session data, ensuring secure storage.
+//
+// Parameters:
+//   - deadline (time.Time): The expiration time of the session data.
+//   - values (map[string]interface{}): The session values to be encoded and encrypted.
+//
+// Returns:
+//   - []byte: The encrypted session data.
+//   - error: An error if encoding or encryption fails.
+//
+// The function first serializes the input data using gob encoding, then encrypts it using
+// the underlying iocrypter encryption mechanism.
+func (c Codec) Encode(deadline time.Time, values map[string]interface{}) ([]byte, error) {
+	aux := &struct {
+		Deadline time.Time
+		Values   map[string]interface{}
+	}{
+		Deadline: deadline,
+		Values:   values,
+	}
+
+	buffer := bytes.NewBuffer(nil)
+	if err := gob.NewEncoder(buffer).Encode(aux); err != nil {
+		return nil, fmt.Errorf("failed to encode session data: %w", err)
+	}
+	encrypter, err := iocrypter.NewEncrypter(buffer, c.pass)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create encrypter: %w", err)
+	}
+	ciphertext := bytes.NewBuffer(nil)
+	if _, err = io.Copy(ciphertext, encrypter); err != nil {
+		return nil, fmt.Errorf("failed to encrypt session data: %w", err)
+	}
+
+	return ciphertext.Bytes(), nil
+}
+
+// Decode decrypts and deserializes session data, restoring the original values.
+//
+// Parameters:
+//   - ciphertext ([]byte): The encrypted session data to be decrypted and decoded.
+//
+// Returns:
+//   - time.Time: The original session expiration time.
+//   - map[string]interface{}: The restored session values.
+//   - error: An error if decryption or decoding fails.
+//
+// The function decrypts the given ciphertext using iocrypter and deserializes it back
+// into its structured session representation.
+func (c Codec) Decode(ciphertext []byte) (time.Time, map[string]interface{}, error) {
+	aux := &struct {
+		Deadline time.Time
+		Values   map[string]interface{}
+	}{}
+
+	decrypter, err := iocrypter.NewDecrypter(bytes.NewReader(ciphertext), c.pass)
+	if err != nil {
+		return time.Time{}, nil, fmt.Errorf("failed to decrypt session data: %w", err)
+	}
+	if err = gob.NewDecoder(decrypter).Decode(&aux); err != nil {
+		return time.Time{}, nil, fmt.Errorf("failed to decode session data: %w", err)
+	}
+
+	return aux.Deadline, aux.Values, nil
+}

--- a/scs/scs_codec.go
+++ b/scs/scs_codec.go
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: MIT
 
-// Package scs_codec implements the Codec interface of Alex Edward's SCS Session Management
+// Package scs implements the Codec interface of Alex Edward's SCS Session Management
 // package so that iocrypter can be used for encrypting/authenticating session data before
 // storing them in memory or in any other corrsponding session storage that is supported by
 // SCS.
-package scs_codec
+package scs
 
 import (
 	"bytes"

--- a/scs/scs_codec_test.go
+++ b/scs/scs_codec_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package scs_codec
+package scs
 
 import (
 	"bytes"

--- a/scs/scs_codec_test.go
+++ b/scs/scs_codec_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Winni Neessen <wn@neessen.dev>
+//
+// SPDX-License-Identifier: MIT
+
 package scs_codec
 
 import (

--- a/scs/scs_codec_test.go
+++ b/scs/scs_codec_test.go
@@ -1,0 +1,191 @@
+package scs_codec
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/wneessen/iocrypter"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("New with password succeeds", func(t *testing.T) {
+		passphrase := "verysecretkey"
+		codec := New(passphrase)
+		if codec == nil {
+			t.Fatalf("creating new codec failed, codec is nil")
+		}
+		if !bytes.Equal(codec.pass, []byte(passphrase)) {
+			t.Errorf("creating new codec failed, expected password to be: %q, got: %q", passphrase, codec.pass)
+		}
+	})
+	t.Run("New with empty password fails", func(t *testing.T) {
+		passphrase := ""
+		codec := New(passphrase)
+		if codec == nil {
+			t.Fatalf("creating new codec failed, codec is nil")
+		}
+		_, err := codec.Encode(time.Now(), map[string]interface{}{})
+		if err == nil {
+			t.Errorf("expected encoding to fail with empty password")
+		}
+		if !errors.Is(err, iocrypter.ErrPassPhraseEmpty) {
+			t.Errorf("expected error to be %s, got %s", iocrypter.ErrPassPhraseEmpty, err)
+		}
+	})
+}
+
+func TestCodec_Encode(t *testing.T) {
+	passphrase := "verysecretkey"
+	t.Run("encoding succeeds", func(t *testing.T) {
+		codec := New(passphrase)
+		if codec == nil {
+			t.Fatalf("creating new codec failed, codec is nil")
+		}
+		data := map[string]interface{}{
+			"foo": "bar",
+		}
+		encoded, err := codec.Encode(time.Now(), data)
+		if err != nil {
+			t.Errorf("encoding session data failed: %s", err)
+		}
+		if !bytes.Equal(encoded[:9], []byte{0x00, 0x00, 0x01, 0x00, 0x04, 0x01, 0x00, 0x00, 0x00}) {
+			t.Errorf("expected encoded data to start with magic bytes, got: %x", encoded[:9])
+		}
+	})
+	t.Run("encoding with nil data", func(t *testing.T) {
+		codec := New(passphrase)
+		if codec == nil {
+			t.Fatalf("creating new codec failed, codec is nil")
+		}
+		encoded, err := codec.Encode(time.Now(), nil)
+		if err != nil {
+			t.Errorf("encoding session data failed: %s", err)
+		}
+		if !bytes.Equal(encoded[:9], []byte{0x00, 0x00, 0x01, 0x00, 0x04, 0x01, 0x00, 0x00, 0x00}) {
+			t.Errorf("expected encoded data to start with magic bytes, got: %x", encoded[:9])
+		}
+	})
+	t.Run("encoding with type alias fails", func(t *testing.T) {
+		type Unknown int
+		codec := New(passphrase)
+		if codec == nil {
+			t.Fatalf("creating new codec failed, codec is nil")
+		}
+		data := map[string]interface{}{
+			"foo": Unknown(1),
+		}
+		_, err := codec.Encode(time.Now(), data)
+		if err == nil {
+			t.Errorf("expected encoding to fail with unregistered type alias")
+		}
+	})
+}
+
+func TestCodec_Decode(t *testing.T) {
+	passphrase := "verysecretkey"
+	now := time.Now()
+	codec := New(passphrase)
+	if codec == nil {
+		t.Fatalf("creating new codec failed, codec is nil")
+	}
+	data := map[string]interface{}{
+		"foo": "bar",
+	}
+	encoded, err := codec.Encode(now, data)
+	if err != nil {
+		t.Fatalf("encoding session data failed: %s", err)
+	}
+
+	t.Run("decoding succeeds", func(t *testing.T) {
+		timestamp, decoded, err := codec.Decode(encoded)
+		if err != nil {
+			t.Errorf("decoding session data failed: %s", err)
+		}
+		if !now.Equal(timestamp) {
+			t.Errorf("expected timestamp to be equal want: %s, got: %s", now.String(), timestamp.String())
+		}
+		decodedData, ok := decoded["foo"]
+		if !ok {
+			t.Fatalf("expected decoded data to contain key 'foo'")
+		}
+		if decodedData != "bar" {
+			t.Errorf("expected decoded data to contain value 'bar', got: %s", decodedData)
+		}
+	})
+	t.Run("decoding fails with wrong passphrase", func(t *testing.T) {
+		codec.pass = []byte("wrongpassphrase")
+		t.Cleanup(func() { codec.pass = []byte(passphrase) })
+		_, _, err := codec.Decode(encoded)
+		if err == nil {
+			t.Errorf("expected decoding to fail with wrong passphrase")
+		}
+		if !errors.Is(err, iocrypter.ErrFailedAuthentication) {
+			t.Errorf("expected error to be %s, got %s", iocrypter.ErrFailedAuthentication, err)
+		}
+	})
+	t.Run("decoding with nil data", func(t *testing.T) {
+		_, _, err := codec.Decode(nil)
+		if err == nil {
+			t.Errorf("expected decoding to fail with nil data")
+		}
+	})
+	t.Run("decoding fails with non-gobed data", func(t *testing.T) {
+		encrypter, err := iocrypter.NewEncrypter(bytes.NewBufferString("teststringthatis"), []byte(passphrase))
+		if err != nil {
+			t.Fatalf("failed to create encrypter: %s", err)
+		}
+		buffer := bytes.NewBuffer(nil)
+		if _, err = io.Copy(buffer, encrypter); err != nil {
+			t.Fatalf("failed to encrypt data: %s", err)
+		}
+		_, _, err = codec.Decode(buffer.Bytes())
+		if err == nil {
+			t.Errorf("expected decoding to fail with non-gobed data")
+		}
+	})
+}
+
+func BenchmarkCodec_Encode(b *testing.B) {
+	passphrase := "verysecretkey"
+	codec := New(passphrase)
+	if codec == nil {
+		b.Fatalf("creating new codec failed, codec is nil")
+	}
+	data := map[string]interface{}{
+		"foo": "bar",
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := codec.Encode(time.Now(), data)
+		if err != nil {
+			b.Fatalf("encoding session data failed: %s", err)
+		}
+	}
+}
+
+func BenchmarkCodec_Decode(b *testing.B) {
+	passphrase := "verysecretkey"
+	codec := New(passphrase)
+	if codec == nil {
+		b.Fatalf("creating new codec failed, codec is nil")
+	}
+	data := map[string]interface{}{
+		"foo": "bar",
+	}
+	encoded, err := codec.Encode(time.Now(), data)
+	if err != nil {
+		b.Fatalf("encoding session data failed: %s", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, err := codec.Decode(encoded)
+		if err != nil {
+			b.Fatalf("decoding session data failed: %s", err)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds iocrypter support for Alex Edwards' SCS Codec interface allowing users to encrypt and authenticate session data before storing them in the SCS storage.