### PR TITLE
Add SCS codec implementation details to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ for byte stream encryption.
 The [cmd/](cmd) directory holds two example implementations for tools that will read a file from
 disk and then en- or decrypt it accordingly.
 
+The [scs](scs) directory holds a package that provides an implementation of the
+[Codec interface](https://pkg.go.dev/github.com/alexedwards/scs/v2#Codec) for
+[Alex Edwards' SCS: HTTP Session Management](https://github.com/alexedwards/scs). It enables the use
+of iocrypter to encrypt and authenticate session data before storing them in any supported SCS
+session storage.
+
 ## License
 
 This project is licensed under the MIT License. See the LICENSE file for details.

--- a/scs/README.md
+++ b/scs/README.md
@@ -42,4 +42,4 @@ func main() {
 
 ## License
 
-This package is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+This package is licensed under the MIT License. See [LICENSE](../LICENSE) for details.


### PR DESCRIPTION
Updated the main README to describe the SCS codec package and its purpose. Adjusted the license link in scs/README for proper relative path reference.